### PR TITLE
Support ruby 2.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in fernet.gemspec
 gemspec
+
+gem "oj",    "~> 2.18"
+gem "rake",  "~> 11.0"
+gem "rspec", "~> 2.11"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,16 @@
 PATH
   remote: .
   specs:
-    legacy-fernet (1.6.2)
-      multi_json
+    legacy-fernet (1.6.3)
+      multi_json (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.1.3)
-    multi_json (1.7.9)
-    oj (2.1.4)
+    multi_json (1.12.1)
+    oj (2.18.1)
+    rake (11.3.0)
     rspec (2.11.0)
       rspec-core (~> 2.11.0)
       rspec-expectations (~> 2.11.0)
@@ -25,5 +26,9 @@ PLATFORMS
 
 DEPENDENCIES
   legacy-fernet!
-  oj
-  rspec
+  oj (~> 2.18)
+  rake (~> 11.0)
+  rspec (~> 2.11)
+
+BUNDLED WITH
+   1.13.7

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,7 @@
 #!/usr/bin/env rake
 require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec

--- a/fernet.gemspec
+++ b/fernet.gemspec
@@ -15,8 +15,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Fernet::Legacy::VERSION
 
-  gem.add_dependency "multi_json"
-
-  gem.add_development_dependency "rspec"
-  gem.add_development_dependency "oj"
+  gem.add_dependency "multi_json", "~> 1.0"
 end

--- a/lib/fernet/legacy/generator.rb
+++ b/lib/fernet/legacy/generator.rb
@@ -46,7 +46,7 @@ module Fernet::Legacy
       cipher.encrypt
       iv         = cipher.random_iv
       cipher.iv  = iv
-      cipher.key = encryption_key
+      cipher.key = encryption_key[0, 16]
       @data = cipher.update(MultiJson.dump(data)) + cipher.final
       iv
     end

--- a/lib/fernet/legacy/verifier.rb
+++ b/lib/fernet/legacy/verifier.rb
@@ -75,7 +75,7 @@ module Fernet::Legacy
       decipher = OpenSSL::Cipher.new('AES-128-CBC')
       decipher.decrypt
       decipher.iv  = iv
-      decipher.key = encryption_key
+      decipher.key = encryption_key[0, 16]
       decipher.update(Base64.urlsafe_decode64(encrypted_data)) + decipher.final
     end
 


### PR DESCRIPTION
AES-128-CBC requires keys to be 16 bytes. Previous versions of Ruby/OpenSSL were just accepting longer keys and silently truncating them, but in 2.4 it raises an error instead.